### PR TITLE
TIKU summary supports now sub headers up to three levels

### DIFF
--- a/src/main/java/fi/thl/summary/SummaryReader.java
+++ b/src/main/java/fi/thl/summary/SummaryReader.java
@@ -57,7 +57,7 @@ public class SummaryReader {
 
     private static final String SUPPRESSION_ATTRIBUTE = "suppression";
 
-    private static final List<String> textPresentations = ImmutableList.of("subtitle", "info");
+    private static final List<String> textPresentations = ImmutableList.of("subtitle", "subtitle1", "subtitle2", "subtitle3", "info");
     private static final List<String> dataPresentations = ImmutableList.of("line", "list", "bar", "gauge", "pie", "radar", "map");
     private static final List<String> tablePresentations = ImmutableList.of("table");
 

--- a/src/main/webapp/WEB-INF/ftl/summary.ftl
+++ b/src/main/webapp/WEB-INF/ftl/summary.ftl
@@ -18,6 +18,16 @@
     [#return "- ${code} - " /]
 [/#function]
 
+[#function subtitleHeadingLevel presentation]
+	[#assign headingLevel = presentation.type?keep_after("subtitle") /]
+    [#if headingLevel == "" || !["1", "2", "3"]?seq_contains(headingLevel)]
+        [#assign headingLevel = "3" /]
+    [#else]
+        [#assign headingLevel = headingLevel?number + 2 /]          
+    [/#if]
+	[#return headingLevel]
+[/#function]
+
 [#macro show_filter_values presentation]
 
 [/#macro]
@@ -188,13 +198,14 @@
             <p>
                 hidden
             </p>
-      [#elseif "subtitle" = presentation.type]
-          <h3>
+      [#elseif (presentation.type!"")?starts_with("subtitle")]
+          [#assign headingLevel = subtitleHeadingLevel(presentation) /]
+          <h${headingLevel}>
               ${presentation.getContent(lang)}
-          </h3>
+          </h${headingLevel}>
       [#elseif "info" = presentation.type]
           <p>
-                   ${presentation.getContent(lang)}
+              ${presentation.getContent(lang)}
           </p>
       [#elseif "bar" = presentation.type  || "barstacked" = presentation.type || "barstacked100" = presentation.type]
           [@show_filter_values presentation /]
@@ -353,7 +364,7 @@
       [#assign containsMap = true]
       [#else]
       <h3>${presentation.type}</h3>
-      <p>${presentation.content}</p>
+      <p>${presentation.content!""}</p>
       [/#if]
 
 


### PR DESCRIPTION
Sub headers can be specified with following node types:
subheader  -> html element h3
subheader1 -> html element h3
subheader2 -> html element h4
subheader3 -> html elemen  h5

Issue PIVOT-657