### PR TITLE
Fixed a bug with map tooltips

### DIFF
--- a/src/main/webapp/resources/css/summary.css
+++ b/src/main/webapp/resources/css/summary.css
@@ -209,6 +209,7 @@
       border: 1px solid #b2b2b2;
       border-radius: 2px 2px 2px 2px;
       z-index: 10000;
+      pointer-events: none;
     }
     .presentation .dropdown-menu {
       text-align: left;


### PR DESCRIPTION
Problem was that tooltip is showed when mouse enters region on map, and
it is hidden if mouse enters on tooltip itself. Position of tooltip is
such that it was almost always hidden instantly after it was showed.
Issue PIVOT-682

Change-Id: I9e0638fdab1f5e9b7defccc7a1b83fb45590ae7b