### PR TITLE
'Read more' link on summary page is now opened in new tab

### DIFF
--- a/src/main/webapp/WEB-INF/ftl/summary.ftl
+++ b/src/main/webapp/WEB-INF/ftl/summary.ftl
@@ -476,6 +476,12 @@
       </div>
       [/#if]
       <div class="btn-group pull-right help" role="group">
+        [#if summary.link.getValue(lang)?? && !summary.link.getValue(lang)?ends_with('n/a')]
+        <a href="${summary.link.getValue(lang)}" target="_blank" type="submit" class="btn btn-default">
+          <span class="glyphicon glyphicon-info-sign"></span>
+          <span class="hide-xs">${message("summary.more")}</span>
+        </a>
+        [/#if]
         <a href="${message("site.help.url")}" target="_blank" type="submit" class="btn btn-default">
           <span class="glyphicon glyphicon-question-sign"></span>
           <span class="hide-xs">${message("site.help")}</span>
@@ -512,7 +518,6 @@
                   [#else]
                   <p>${summary.note.getValue(lang)!}</p>
                   [/#if]
-                  <p><a href="${summary.link.getValue(lang)!}">${message("summary.more")}</a></p>
 
                   [@summary_presentations /]
                 </div>


### PR DESCRIPTION
Link was also moved to 'blue stripe' (same as on cube page)
Issue PIVOT-664
Change-Id: Iac6b3446ffe9b39e6e4347ec5523708867262130