### PR TITLE
Added new chart type which is based on column chart.

### DIFF
--- a/src/main/java/fi/thl/summary/SummaryReader.java
+++ b/src/main/java/fi/thl/summary/SummaryReader.java
@@ -529,6 +529,10 @@ public class SummaryReader {
             p.setFirst("begin".equals(attribute(node, "group")));
             p.setLast("end".equals(attribute(node, "group")));
 
+            MeasureItem widthMeasure = extractWidthMeasure(node);
+            if (widthMeasure != null) {
+                p.setWidthMeasure(widthMeasure);
+            }
 
             Node ruleNode = firstChildNode(node, "rule");
             if(null != ruleNode) {
@@ -538,6 +542,19 @@ public class SummaryReader {
             }
 
             return p;
+        }
+
+        private MeasureItem extractWidthMeasure(Node node) {
+            NodeList children = node.getChildNodes();
+            for (int i = 0; i < children.getLength(); ++i) {
+                Node child = children.item(i);
+                if ("widthmeasure".equals(child.getNodeName())) {
+                    return new MeasureItem(MeasureItem.Type.LABEL, child.getTextContent());
+                } else if ("widthref".equals(child.getNodeName())) {
+                    return new MeasureItem(MeasureItem.Type.REFERENCE, child.getTextContent());
+                } 
+            }
+            return null;
         }
 
         private Integer parseIntAttribute(Node node, String a) {
@@ -729,13 +746,21 @@ public class SummaryReader {
     private static List<MeasureItem> listMeasures(Node parent) {
         List<MeasureItem> measures = Lists.newArrayList();
         NodeList children = parent.getChildNodes();
+        MeasureItem widthMeasure = null;
         for (int i = 0; i < children.getLength(); ++i) {
             Node child = children.item(i);
             if ("measureref".equals(child.getNodeName())) {
                 measures.add(new MeasureItem(MeasureItem.Type.REFERENCE, child.getTextContent()));
             } else if ("measure".equals(child.getNodeName())) {
                 measures.add(new MeasureItem(MeasureItem.Type.LABEL, child.getTextContent()));
+            } else if ("widthref".equals(child.getNodeName())) {
+                widthMeasure = new MeasureItem(MeasureItem.Type.REFERENCE, child.getTextContent());
+            } else if ("widthmeasure".equals(child.getNodeName())) {
+                widthMeasure = new MeasureItem(MeasureItem.Type.LABEL, child.getTextContent());
             }
+        }
+        if (widthMeasure != null) {
+            measures.add(widthMeasure);
         }
         return measures;
     }

--- a/src/main/java/fi/thl/summary/model/DataPresentation.java
+++ b/src/main/java/fi/thl/summary/model/DataPresentation.java
@@ -19,6 +19,7 @@ public class DataPresentation implements Presentation {
     private String palette;
     private List<SummaryItem> dimensions = new ArrayList<>();
     private SummaryMeasure measures = new SummaryMeasure();
+    private MeasureItem widthMeasure;
     private List<Selection> filter = new ArrayList<>();
     private Presentation.SortMode sortMode = SortMode.none;
 
@@ -206,4 +207,13 @@ public class DataPresentation implements Presentation {
     public Rule getRule() {
         return rule;
     }
+
+    public MeasureItem getWidthMeasure() {
+    	return widthMeasure;
+    }
+
+    public void setWidthMeasure(MeasureItem widthMeasure) {
+		this.widthMeasure = widthMeasure;
+	}
+
 }

--- a/src/main/java/fi/thl/summary/model/MeasureItem.java
+++ b/src/main/java/fi/thl/summary/model/MeasureItem.java
@@ -8,6 +8,7 @@ public class MeasureItem {
 
     private final Type type;
     private final String code;
+    private Integer surrogateId;
 
     public MeasureItem(Type type, String code) {
         this.type = type;
@@ -21,6 +22,14 @@ public class MeasureItem {
     public String getCode() {
         return code;
     }
+
+	public Integer getSurrogateId() {
+		return surrogateId;
+	}
+
+	public void setSurrogateId(Integer surrogateId) {
+		this.surrogateId = surrogateId;
+	}
 
     @Override
     public int hashCode() {

--- a/src/main/java/fi/thl/summary/model/hydra/HydraDataPresentation.java
+++ b/src/main/java/fi/thl/summary/model/hydra/HydraDataPresentation.java
@@ -11,6 +11,7 @@ import com.google.common.collect.Lists;
 import fi.thl.pivot.datasource.HydraSource;
 import fi.thl.pivot.model.IDimensionNode;
 import fi.thl.summary.model.DataPresentation;
+import fi.thl.summary.model.MeasureItem;
 import fi.thl.summary.model.Presentation;
 import fi.thl.summary.model.Selection;
 import fi.thl.summary.model.Summary;
@@ -297,6 +298,16 @@ public class HydraDataPresentation extends DataPresentation {
     @Override
     public Legendless getLegendless() {
         return delegate.getLegendless();
+    }
+
+    @Override
+    public MeasureItem getWidthMeasure() {
+    	MeasureItem wm = delegate.getWidthMeasure();
+    	if (wm != null) {
+        	IDimensionNode n = source.findNodeByName(wm.getCode(), summary.getItemLanguage());
+        	wm.setSurrogateId(n.getSurrogateId());    		
+    	}
+    	return wm;
     }
 
 }

--- a/src/main/java/fi/thl/summary/model/hydra/MeasureExtension.java
+++ b/src/main/java/fi/thl/summary/model/hydra/MeasureExtension.java
@@ -63,7 +63,7 @@ public class MeasureExtension extends SummaryMeasure implements Extension {
 
     }
 
-    private IDimensionNode findNode(String language, String item) {
+    public IDimensionNode findNode(String language, String item) {
         for (fi.thl.pivot.model.Dimension dim : source.getMeasures()) {
             DimensionLevel level = dim.getRootLevel();
             while (!leafLevelReached(level)) {

--- a/src/main/webapp/WEB-INF/ftl/summary.ftl
+++ b/src/main/webapp/WEB-INF/ftl/summary.ftl
@@ -229,7 +229,7 @@
           [#assign emindex = 0 /]
           <div
               id="$[#if presentation.id??]${presentation.id!}[#else]p${presentation_index}[/#if]"
-              class="presentation column"
+              class="presentation column[#if presentation.widthMeasure??]-mekko[/#if]"
               [#if "columnstacked" = presentation.type]data-stacked="true"[/#if]
               [#if "columnstacked100" = presentation.type]data-stacked="true" data-percent="true"[/#if]
               [#if presentation.min??]data-min="${presentation.min}"[/#if]
@@ -238,7 +238,8 @@
               [#if presentation.emphasizedNode??]data-em="[#list presentation.emphasizedNode as n][#if n??][#if emindex>0],[/#if][#assign emindex=1/]${n.surrogateId}[/#if][/#list]"[/#if]
               data-ref="${factTable}.json?${presentation.dataUrl}"
               data-sort="${presentation.sortMode}"
-              [#if presentation.legendless??]data-legendless="${presentation.legendless}"[/#if]>
+              [#if presentation.legendless??]data-legendless="${presentation.legendless}"[/#if]
+              [#if presentation.widthMeasure??]data-width-measure="${presentation.widthMeasure.surrogateId!'N/A'}"[/#if]>
               [@export presentation "image" /]
               <img src="${rc.contextPath}/resources/img/loading.gif" alt="loading"/>
           </div>

--- a/src/main/webapp/resources/js/summary.js
+++ b/src/main/webapp/resources/js/summary.js
@@ -78,8 +78,8 @@ function selectChartType (e) {
   }
 
   thl.pivot = thl.pivot || {};
-  thl.pivot.svgToImg = function (doc, width, height, opt, callback) {   
-    var isMap = false; 
+  thl.pivot.svgToImg = function (doc, width, height, opt, callback) {
+    var isMap = false;
     if (opt.legendData) {         
       isMap = true;
     }      
@@ -243,7 +243,7 @@ function selectChartType (e) {
     $(opt.target[0]).find('.img-action a').each(function (e) {
       var width = 600;
       var height = 400;      
-      var link = $(this);      
+      var link = $(this);
       if (link.attr('href') === '#') {
         var svg = $(this).closest('.presentation').find('svg');             
         thl.pivot.svgToImg(svg, +width, +height, opt, function (canvas) {

--- a/src/main/webapp/resources/js/summary.js
+++ b/src/main/webapp/resources/js/summary.js
@@ -1356,6 +1356,11 @@ function selectChartType (e) {
                 .on('mousemove', moveToolTip)
                 .append('svg:title')
                 .text(function (d, i) {
+                  if (opt.type === 'columnmekkochart') {
+                    var itemIndex = columnMekkoChartData[i].itemIndex;
+                    var widthMeasureValue = opt.callback(widthMeasureIndex, itemIndex);
+                    return label(d, itemIndex, series) + '(' + labels[opt.widthmeasure] + ' ' + widthMeasureValue + '): ' + numberFormat(opt.callback(series, itemIndex));
+                  }
                   return label(d, i, series) + '(' + labels[d] + '): ' + numberFormat(opt.callback(series, i));
                 });
 
@@ -2197,7 +2202,7 @@ function selectChartType (e) {
               }
               var label = labels[labelSeries[i]];
               if (opt.type === 'columnmekkochart') {
-                label = 'x: ' + label + ', y: ' + labels[opt.widthmeasure];
+                label = 'x: ' + labels[opt.widthmeasure] + ', y: ' + label;
               }
 
               if (lastLegendGroup != null) {


### PR DESCRIPTION
Column height and width are both read from data. Width measure is
specified in summary presentation and it is added as a 'normal' measure
to summary so it appears correctly in data url. Svg drawing is based on
column chart but was separated from it to keep code cleaner. We have to
calculate column widths and locations before actual drawing, because of
the difficulties with matching column sizes with x-axis tick positions
(especially when data is sorted based on column heights).

Issue PIVOT-660