### PR TITLE
Fixed PIVOT-660 on IE

### DIFF
--- a/src/main/webapp/resources/js/summary.js
+++ b/src/main/webapp/resources/js/summary.js
@@ -2244,7 +2244,8 @@ function selectChartType (e) {
             xAxis
               .ticks(opt.dataset.Dimension(0).length)
               .tickValues(function() {
-                return Object.values(columnMekkoChartData)
+                return Object.keys(columnMekkoChartData)
+                  .map(function(key) { return columnMekkoChartData[key]; })
                   .sort(function(a, b) { return a.sortOrder - b.sortOrder; })
                   .map(function(dataItem) { return dataItem.itemXPosition});
               });


### PR DESCRIPTION
Minor change to implementation because IE does not support Object.values
Change-Id: I971f7c6de17d99556fcd6810fec43cd55a66a276