### PR TITLE
PIVOT-856_PIVOT-855_PIVOT-853_PIVOT-852_PIVOT-854_PIVOT-842

### DIFF
--- a/src/main/java/fi/thl/pivot/export/PdfExporter.java
+++ b/src/main/java/fi/thl/pivot/export/PdfExporter.java
@@ -5,6 +5,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
+import java.util.Locale;
 
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
@@ -29,9 +30,11 @@ public class PdfExporter {
     private final Logger logger = LoggerFactory.getLogger(PdfExporter.class);
  
     private FreeMarkerConfig freemarker;
+    private Locale locale;
 
     public PdfExporter(String language, FreeMarkerConfig configurer) {
         this.freemarker = configurer;
+        this.locale = new Locale(language);
     }
 
     public void export(Model model, OutputStream out) throws IOException {
@@ -79,7 +82,7 @@ public class PdfExporter {
 
         
         final Configuration configuration = freemarker.getConfiguration();
-        Template tmpl = configuration.getTemplate("cube.pdf.ftl");
+        Template tmpl = configuration.getTemplate("cube.pdf.ftl", locale);
         tmpl.process(model.asMap(), writer);
         writer.flush();
         return bos;

--- a/src/main/java/fi/thl/pivot/web/CubePdfController.java
+++ b/src/main/java/fi/thl/pivot/web/CubePdfController.java
@@ -84,7 +84,7 @@ public class CubePdfController extends AbstractCubeController {
             }
 
             model.addAttribute("tableBounds", calculateSplitTableBounds(cs));
-            model.addAttribute("messageSource", new MessageSourceWrapper(messageSource, "fi"));
+            model.addAttribute("messageSource", new MessageSourceWrapper(messageSource, cubeRequest.getUiLanguage()));
 
             new PdfExporter(cubeRequest.getUiLanguage(), freemarker).export(model, resp.getOutputStream());
         } else {

--- a/src/main/resources/static/css/style.css
+++ b/src/main/resources/static/css/style.css
@@ -915,6 +915,22 @@ a:focus, a:hover {
 	text-align: center;
 }
 
+.lnk-btn {
+	padding: 6px 12px;
+	text-decoration: none!important;
+}
+
+.lnk-btn:hover {
+	background-color: #e6e6e6;
+	border-radius: 4px;
+	max-height: 33px;
+}
+
+.lnk-btn:hover span,
+.lnk-btn:hover i {
+	color: #212529;
+}
+
 @media screen and (max-width: 767px) {
 
 	.pivot-header #languages {

--- a/src/main/resources/static/css/summary.css
+++ b/src/main/resources/static/css/summary.css
@@ -411,6 +411,18 @@
    padding-right: 24px;
  }
 
+.form-group.search ul.dropdown-menu li a {
+  color: #555;
+}
+
+.dropdown-menu small.dropdown-close {
+  padding: 0 15px;
+}
+
+.dropdown-menu small.dropdown-close a {
+  color: #005c9e!important;
+}
+
 .table-responsive > .table {
   margin-bottom: 0;
 }
@@ -527,6 +539,9 @@ span.disc::after {
        background: #efefef;
        display: table-cell;
        float: none;
+   }
+   .p-left {
+    padding-left: 8px;
    }
 }
 @media screen and (min-width: 768px) {

--- a/src/main/resources/static/js/summary.js
+++ b/src/main/resources/static/js/summary.js
@@ -864,7 +864,7 @@ function selectChartType (e) {
             var cell;
             if (val == null || val.value === null) {
               cell = $('<td >')
-                .append('<span>..</span>')
+                .append('<span class="p-left">..</span>')
                 .css('text-align', opt.align[0])
               row.append(cell);
               if(hasValue || opt.suppress === 'none' || opt.suppress === 'zero') {
@@ -887,7 +887,7 @@ function selectChartType (e) {
               if ((+val.value<0 && negatives) || (+val.value===0 && zeros)){
                 tdAndClass = '<td class="text-danger">';
               }
-              var span = $('<span class="text-align-center"></span>')
+              var span = $('<span></span>')
                 .text(content)
                 .addClass(cls + i);
               cell = $(tdAndClass);

--- a/src/main/resources/templates/cube.pdf.ftl
+++ b/src/main/resources/templates/cube.pdf.ftl
@@ -1,7 +1,6 @@
 [#ftl]<?xml version='1.0' encoding='UTF-8'?>
 <!DOCTYPE html>
 
-[#setting locale="fi"]
 [#function value val]
     [#if val?matches("\\d+,\\d+")][#return val?replace(",",".")?number?string(",##0.00")/][/#if]
     [#if val?matches("\\d+")][#return val?number?string(",##0")/][/#if]

--- a/src/main/resources/templates/cube/cube-toolbar.ftl
+++ b/src/main/resources/templates/cube/cube-toolbar.ftl
@@ -2,7 +2,7 @@
 <div id="toolbar-left">
 <div class="btn-group" role="group">
     <div class="dropdown">
-        <button class="btn btn-secondary" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false" aria-label="...">${message("cube.options")}</button>
+        <button class="btn btn-secondary" type="button" id="dropdownMenuButton1" data-bs-toggle="dropdown" aria-expanded="false" aria-label="...">${message("cube.options")}<span class="caret"></span></button>
         <ul class="dropdown-menu" aria-labelledby="dropdownMenuButton1">
             <li class="reset-action" role="presentation"><a class="dropdown-item" role="menuitem"><span class="fas fa-sync"></span> ${message("cube.reset")}</a></li>
             <li class="transpose-action" role="presentation"><a class="dropdown-item" role="menuitem"><span class="fas fa-expand-alt"></span> ${message("cube.transpose")}</a></li>
@@ -62,20 +62,20 @@
     </div>
 
     [#if backUrl??]
-    <a class="btn btn-secondary" href="${rc.contextPath}/${backUrl}">
+    <a class="lnk-btn" href="${rc.contextPath}/${backUrl}">
         <i class="fas fa-th"></i>
         <span class="hide-xs">${message("site.changeMaterial")}</span>
     </a>
     [/#if]
 
     [#if metaLink??]
-      <a class="btn btn-secondary" target="_blank" href="${metaLink.getValue(lang)}">
+      <a class="lnk-btn" target="_blank" href="${metaLink.getValue(lang)}">
         <span class="fas fa-info-circle"></span>
         <span class="hide-xs">${message("summary.more")}</span>
       </a>
     [/#if]
 
-    <a href="${message("site.help.url")}" target="_blank" type="submit" class="btn btn-secondary">
+    <a class="lnk-btn" target="_blank" href="${message("site.help.url")}" type="submit">
       <span class="fas fa-question-circle"></span>
       <span class="hide-xs">${message("site.help")}</span>
     </a>

--- a/src/main/resources/templates/summary.ftl
+++ b/src/main/resources/templates/summary.ftl
@@ -53,7 +53,7 @@
     [/#list]
     [#if mapLevels?? && mapLevels?size > 1]
     <div class="form-group">
-      <label for="geo">
+      <label class="bold" for="geo">
         [#if lang="en"]Select region
         [#elseif lang="sv"]Välj områden
         [#else]Valitse aluejako
@@ -90,7 +90,7 @@
                     <input class="form-control search-control" placeholder="[#if filterStage.selected??]${filterStage.selected[0].label.getValue(lang)}[/#if]"/>
                 </div>
               <ul class="dropdown-menu">
-                <li><small class="float-end" style="padding: 0 15px">
+                <li><small class="float-end dropdown-close">
                   <a href="#">
                   [#if lang="en"]close
                   [#elseif lang="sv"]stäng
@@ -606,7 +606,7 @@
     <script src="${resourceUrl}/js/json-stat.js"></script>
     [#--<script src="${resourceUrl}/js/jspdf.min.js"></script>--]
     <script src="${rc.contextPath}/js/map-palette.min.js?v=${buildTimestamp}"></script>
-    <script src="${rc.contextPath}/js/summary.min.js?v=${buildTimestamp}"></script>
+    <script src="${rc.contextPath}/js/summary.js?v=${buildTimestamp}"></script>
 
     <script nonce="${cspNonce}">
     var labels = {},


### PR DESCRIPTION
-PIVOT-856, When drilling down in maps is possible, selection element
should have bold text in label
-PIVOT-855, Selection-element Search has blue text instead of normal
-PIVOT-853, Options has lost the arrow after text
-PIVOT-852, Read more and Help remain grey after having been clicked
-PIVOT-854, Language versions won´t work properly in Export pdf
-PIVOT-842, Figures in summary tables aren't lined properly: tens,
hundreds, decimals etc should be vertically in the same line